### PR TITLE
Don't rebuild the template list on the home screen unless necessary

### DIFF
--- a/src/shared/templates/templates.js
+++ b/src/shared/templates/templates.js
@@ -5,18 +5,26 @@ var everlive = require("../everlive/everlive");
 var localStorage = require("../local-storage/local-storage");
 var analyticsMonitor = require("../analytics");
 
+var newTemplatesAvailable = false;
+
 module.exports = {
 	getMyMemes: function(callback) {
 		return _getMyMemes(callback);
 	},
 	getTemplates: function(callback) {
+		newTemplatesAvailable = false;
 		return _getTemplates(callback);
 	},
 	addNewPublicTemplate: function(fileName, imageSource) {
+		newTemplatesAvailable = true;
 		return _addNewPublicTemplate(fileName, imageSource);
 	},
 	addNewLocalTemplate: function(fileName, imageSource) {
+		newTemplatesAvailable = true;
 		return _addNewLocalTemplate(fileName, imageSource);
+	},
+	areNewTemplatesAvailable: function() {
+		return newTemplatesAvailable;
 	}
 };
 

--- a/src/views/home/home.js
+++ b/src/views/home/home.js
@@ -56,9 +56,16 @@ exports.createNewTemplate = function() {
 function populateTemplates() {
 	//Get our parent element such that we can add our items to it dynamically
 	var container = _page.getViewById("templateContainer");
+
+	//If we've already loaded templates and no new ones are available there's no
+	//need to rebuild the list.
+	if (container.getChildrenCount() > 0 && !templates.areNewTemplatesAvailable()) {
+		return;
+	}
+
 	clearOldMemes(container);
 
-	templates.getTemplates(function(imageSource){
+	templates.getTemplates(function(imageSource) {
 		var image = new imageModule.Image();
 		image.imageSource = imageSource;
 
@@ -76,7 +83,7 @@ function populateMyMemes() {
 	var container = _page.getViewById("myMemeContainer");
 	clearOldMemes(container);
 
-	templates.getMyMemes(function(imageSource, fileName){
+	templates.getMyMemes(function(imageSource, fileName) {
 		//Create a new image element
 		var image = new imageModule.Image();
 		image.imageSource = imageSource;
@@ -99,7 +106,7 @@ function myMemesActionSheet(imageSource, imageFileName) {
 		actions: ["Delete", "Delete All", "Share"]
 	};
 
-	dialogsModule.action(options).then(function (result) {
+	dialogsModule.action(options).then(function(result) {
 		switch (result) {
 			case "Delete" :
 				analyticsMonitor.trackFeature("Home.ActionSheet.Delete");
@@ -154,7 +161,6 @@ function deleteAllMemes() {
 }
 
 function clearOldMemes(container) {
-
 	for (var i = container.getChildrenCount() - 1; i >= 0; i-- ) {
 		var childItem = container.getChildAt(i);
 


### PR DESCRIPTION
Ping @csell5.

This isn't the most elegant solution but it does prevent the home screen from awkwardly reloading. Long term I think we want to fundamentally rethink the way the list of templates gets built.

If you're cool with this approach I'll merge it in.